### PR TITLE
Add support for commonly used message properties

### DIFF
--- a/doc/amqp.md
+++ b/doc/amqp.md
@@ -9,6 +9,9 @@ Synopsis
 
     % SELECT amqp.publish(broker_id, 'amqp.direct', 'foo', 'message');
 
+    % Publishing messages with properties
+    % SELECT amqp.publish(broker_id, 'amqp.direct', 'foo', 'message', 1, 
+          		'application/json', 'some_reply_to', 'correlation_id');
 Description
 -----------
 
@@ -21,6 +24,16 @@ Insert AMQP broker information (host/port/user/pass) into the
 `amqp.broker` table.
 
 A process starts and connects to PostgreSQL and runs:
+
+    SELECT amqp.publish(broker_id, 'amqp.direct', 'foo', 'message', 1, 
+			'application/json', 'some_reply_to', 'correlation_id');
+
+The last four parameters are optional and define the message properties. The parameters
+are: delivery_mode (either 1 or 2, persistent, non-persistent respectively), content_type,
+reply_to and correlation_id.
+
+Given that message parameters are optional, the function can be called without any of those in
+which case no message properties are sent, as in:
 
     SELECT amqp.publish(broker_id, 'amqp.direct', 'foo', 'message');
 

--- a/sql/amqp--unpackaged--0.3.0.sql
+++ b/sql/amqp--unpackaged--0.3.0.sql
@@ -1,6 +1,8 @@
 ALTER EXTENSION amqp ADD table @extschema@.broker;
 ALTER EXTENSION amqp ADD sequence @extschema@.broker_broker_id_seq;
 ALTER EXTENSION amqp ADD function @extschema@.disconnect(integer);
-ALTER EXTENSION amqp ADD function @extschema@.autonomous_publish(integer,character varying,character varying,character varying);
-ALTER EXTENSION amqp ADD function @extschema@.publish(integer,character varying,character varying,character varying);
+ALTER EXTENSION amqp ADD function @extschema@.autonomous_publish(integer,character varying,character varying,character varying, integer default null,
+								 varchar default null, varchar default null, varchar default null);
+ALTER EXTENSION amqp ADD function @extschema@.publish(integer,character varying,character varying,character varying, integer default null,
+						      varchar default null, varchar default null, varchar default null);
 ALTER EXTENSION amqp ADD function @extschema@.exchange_declare(integer,character varying,character varying,boolean,boolean,boolean);

--- a/sql/amqp.sql
+++ b/sql/amqp.sql
@@ -10,23 +10,29 @@ comment on function amqp.exchange_declare(integer, varchar, varchar, boolean, bo
 auto_delete should be set to false as unexpected errors can cause disconnect/reconnect which
 would trigger the auto deletion of the exchange.';
 
-create function amqp.publish(integer, varchar, varchar, varchar)
+create function amqp.publish(integer, varchar, varchar, varchar, integer default null, 
+			     varchar default null, varchar default null, varchar default null)
 returns boolean as 'pg_amqp.so', 'pg_amqp_publish'
 language C immutable;
 
-comment on function amqp.publish(integer, varchar, varchar, varchar) is
+comment on function amqp.publish(integer, varchar, varchar, varchar, integer,
+				 varchar, varchar, varchar) is
 'Publishes a message (broker_id, exchange, routing_key, message).  The message will only
 be published if the containing PostgreSQL transaction successfully commits.  Under certain
-circumstances, the AMQP commit might fail.  In this case, a WARNING is emitted.
+circumstances, the AMQP commit might fail.  In this case, a WARNING is emitted. The last
+four parameters are optional and set the following message properties: delivery_mode (either 1 or 2), 
+content_type, reply_to and correlation_id.
 
 Publish returns a boolean indicating if the publish command was successful.  Note that as
 AMQP publish is asynchronous, you may find out later it was unsuccessful.';
 
-create function amqp.autonomous_publish(integer, varchar, varchar, varchar)
+create function amqp.autonomous_publish(integer, varchar, varchar, varchar, integer default null,
+					varchar default null, varchar default null, varchar default null)
 returns boolean as 'pg_amqp.so', 'pg_amqp_autonomous_publish'
 language C immutable;
 
-comment on function amqp.autonomous_publish(integer, varchar, varchar, varchar) is
+comment on function amqp.autonomous_publish(integer, varchar, varchar, varchar, integer,
+					    varchar, varchar, varchar) is
 'Works as amqp.publish does, but the message is published immediately irrespective of the
 current transaction state.  PostgreSQL commit and rollback at a later point will have no
 effect on this message being sent to AMQP.';

--- a/src/pg_amqp.c
+++ b/src/pg_amqp.c
@@ -278,6 +278,8 @@ pg_amqp_publish_opt(PG_FUNCTION_ARGS, int channel) {
   struct brokerstate *bs;
   if(!PG_ARGISNULL(0)) {
     int broker_id;
+    amqp_basic_properties_t properties;
+    
     int once_more = 1;
     broker_id = PG_GETARG_INT32(0);
   redo:
@@ -289,13 +291,50 @@ pg_amqp_publish_opt(PG_FUNCTION_ARGS, int channel) {
       amqp_boolean_t immediate = 0;
       amqp_bytes_t exchange_b = amqp_cstring_bytes("amq.direct");
       amqp_bytes_t routing_key_b = amqp_cstring_bytes("");
-      amqp_bytes_t body_b = amqp_cstring_bytes("");
+      amqp_bytes_t body_b = amqp_cstring_bytes(""); 
+      properties._flags = 0;
+      
+      /* Sets delivery_mode */
+      if (!PG_ARGISNULL(4)) {
+	  if (PG_GETARG_INT32(4) == 1 || PG_GETARG_INT32(4) == 2) {
+	      properties._flags |= AMQP_BASIC_DELIVERY_MODE_FLAG;
+              properties.delivery_mode = PG_GETARG_INT32(4);
+	  } else {
+              elog(WARNING, "Ignored delivery_mode %d, value should be 1 or 2", 
+                  PG_GETARG_INT32(4));
+	  }
+      }
 
+      /* Sets content_type */
+      if (!PG_ARGISNULL(5)) {
+	  properties._flags |= AMQP_BASIC_CONTENT_TYPE_FLAG;
+	  set_bytes_from_text(properties.content_type, 5);
+      }
+
+      /* Sets reply_to */
+      if (!PG_ARGISNULL(6)) {
+	  properties._flags |= AMQP_BASIC_REPLY_TO_FLAG;
+	  set_bytes_from_text(properties.reply_to, 6);
+      }
+
+      /* Sets correlation_id */
+      if (!PG_ARGISNULL(7)) {
+	  properties._flags |= AMQP_BASIC_CORRELATION_ID_FLAG;
+	  set_bytes_from_text(properties.correlation_id, 7);
+      }
+      
       set_bytes_from_text(exchange_b,1);
       set_bytes_from_text(routing_key_b,2);
       set_bytes_from_text(body_b,3);
-      rv = amqp_basic_publish(bs->conn, channel, exchange_b, routing_key_b,
-                              mandatory, immediate, NULL, body_b);
+
+      if (properties._flags == 0) {
+          rv = amqp_basic_publish(bs->conn, channel, exchange_b, routing_key_b,
+                                  mandatory, immediate, NULL, body_b);
+      } else {
+          rv = amqp_basic_publish(bs->conn, channel, exchange_b, routing_key_b,
+                                  mandatory, immediate, &properties, body_b);
+      }
+
       reply = amqp_get_rpc_reply();
       if(rv || reply->reply_type != AMQP_RESPONSE_NORMAL) {
         if(once_more && (channel == 1 || bs->uncommitted == 0)) {


### PR DESCRIPTION
This pull adds support for the most common message properties used when working with RabbitMQ, such properties being: delivery_mode, content_type, reply_to and correlation_id.

The SQL functions have been edited in a way that shouldn't disrupt current implementations of this extension thus keeping the original calls to `amqp.publish` and `amqp.autonmous_publish` functional despite the added parameters.

A few notes: 

* delivery_mode should be an integer, either 1 or 2, however, sending something different (like 3 or 10) doesn't prevent the message to be published, it just doesn't set the delivery_mode property associated with it and raise a warning on postgresql log.
* Again, this adds support for 4 properties of the 14 defined in the AMQP protocol, this is intentional and was based on information from the current [RabbitMQ documentation](https://www.rabbitmq.com/tutorials/tutorial-six-java.html)
* The code used to verify if properties should be sent or not could be improved I think.