### PR TITLE
src: client connection will default sever max channel count

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+0.4.2
+--  Sets the maximum channels for a connection to that of the server which has been changed from 0 to 2047 in recent version of rabbitmq
 0.4.1
 -- Clarify commit warning messages with error codes. Also corrected the warning message for rollbacks (Github Pull Request #15).
 

--- a/META.json
+++ b/META.json
@@ -1,7 +1,7 @@
 {
    "name": "pg_amqp",
    "abstract": "AMQP protocol support for PostgreSQL",
-   "version": "0.4.1",
+   "version": "0.4.2",
    "description": "The pg_amqp package provides the ability for postgres statements to directly publish messages to an AMQP broker.",
    "maintainer": 
        [ "Theo Schlossnagle <jesus@omnti.com>", "Keith Fiske <keith@keithf4.com" ] 

--- a/amqp.control
+++ b/amqp.control
@@ -1,6 +1,6 @@
 # amqp extension
 comment = 'AMQP protocol support for PostgreSQL'
-default_version = '0.4.1'
+default_version = '0.4.2'
 module_pathname = '$libdir/pg_amqp'
 relocatable = false
 schema = amqp

--- a/src/librabbitmq/amqp_socket.c
+++ b/src/librabbitmq/amqp_socket.c
@@ -386,7 +386,7 @@ static int amqp_login_inner(amqp_connection_state_t state,
     server_heartbeat = s->heartbeat;
   }
 
-  if (server_channel_max != 0 && server_channel_max < channel_max) {
+  if (server_channel_max != 0 && (server_channel_max < channel_max || channel_max == 0)) {
     channel_max = server_channel_max;
   }
 


### PR DESCRIPTION


recent version of rabbit changed the maximum number of channels per
connection to 2047 rather than 0(infinity).