### PR TITLE
fix: Update pg_amqp.c

### DIFF
--- a/src/pg_amqp.c
+++ b/src/pg_amqp.c
@@ -137,7 +137,7 @@ void _PG_init() {
 }
 
 static struct brokerstate *
-local_amqp_get_a_bs(broker_id) {
+local_amqp_get_a_bs(int broker_id) {
   struct brokerstate *bs;
   for(bs = HEAD_BS; bs; bs = bs->next) {
     if(bs->broker_id == broker_id) return bs;
@@ -149,7 +149,7 @@ local_amqp_get_a_bs(broker_id) {
   return bs;
 }
 static struct brokerstate *
-local_amqp_get_bs(broker_id) {
+local_amqp_get_bs(int broker_id) {
   char sql[1024];
   char host_copy[300] = "";
   int tries = 0;
@@ -236,7 +236,7 @@ local_amqp_get_bs(broker_id) {
   return bs;
 }
 static void
-local_amqp_disconnect(broker_id) {
+local_amqp_disconnect(int broker_id) {
   struct brokerstate *bs = local_amqp_get_a_bs(broker_id);
   local_amqp_disconnect_bs(bs);
 }


### PR DESCRIPTION
Fixes #41 
Should fix such errors

```
src/pg_amqp.c:140:21: error: parameter 'broker_id' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  140 | local_amqp_get_a_bs(broker_id) {
      |                     ^
src/pg_amqp.c:140:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
  140 | local_amqp_get_a_bs(broker_id) {
      | ^
src/pg_amqp.c:152:19: error: parameter 'broker_id' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  152 | local_amqp_get_bs(broker_id) {
      |                   ^
src/pg_amqp.c:152:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
  152 | local_amqp_get_bs(broker_id) {
      | ^
src/pg_amqp.c:239:23: error: parameter 'broker_id' was not declared, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
  239 | local_amqp_disconnect(broker_id) {
      |                       ^
src/pg_amqp.c:239:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in C2x [-Wdeprecated-non-prototype]
  239 | local_amqp_disconnect(broker_id) {
      | ^
4 warnings and 3 errors generated.
```